### PR TITLE
Add FatalErrorPage and friends

### DIFF
--- a/web/src/index.js
+++ b/web/src/index.js
@@ -1,13 +1,16 @@
 import ReactDOM from 'react-dom'
-import { RedwoodProvider } from '@redwoodjs/web'
+import { RedwoodProvider, FatalErrorBoundary } from '@redwoodjs/web'
 
+import FatalErrorPage from 'src/pages/FatalErrorPage'
 import Routes from 'src/Routes'
 
 import './index.css'
 
 ReactDOM.render(
-  <RedwoodProvider>
-    <Routes />
-  </RedwoodProvider>,
+  <FatalErrorBoundary page={FatalErrorPage}>
+    <RedwoodProvider>
+      <Routes />
+    </RedwoodProvider>
+  </FatalErrorBoundary>,
   document.getElementById('redwood-app')
 )

--- a/web/src/pages/FatalErrorPage/FatalErrorPage.js
+++ b/web/src/pages/FatalErrorPage/FatalErrorPage.js
@@ -1,0 +1,14 @@
+// This page will be rendered when an error makes it all the way to the top of the
+// application without being handled by a Javascript catch statement or React error
+// boundary.
+//
+// You can modify this page as you wish, but it is important to keep things simple to
+// avoid the possibility that it will cause its own error. If it does, Redwood will
+// still render a generic error page, but your users will prefer something a bit more
+// thoughtful. =)
+
+const FatalErrorPage = () => {
+  return <h1>Something went wrong.</h1>
+}
+
+export default FatalErrorPage


### PR DESCRIPTION
Capture fatal errors and show a user-customizable error page when encountered.

Requires https://github.com/redwoodjs/redwood/pull/61 to be merged into @redwoodjs/web first.