### PR TITLE
Tooling for Babel debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 yarn-error.log
 .netlify
 dist/
+dist-babel/
 
 dev.db
 # the photon package will be removed once it is generated properly.

--- a/web/.babelrc.js
+++ b/web/.babelrc.js
@@ -6,7 +6,8 @@ module.exports = {
       {
         targets: "> 0.25%, not dead",
         useBuiltIns: "usage",
-        corejs: 3
+        corejs: 3,
+        modules: false
       }
     ]
   ],

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,8 @@
   },
   "scripts": {
     "dev": "webpack-dev-server --config config/webpack.dev.js",
-    "build": "webpack --config config/webpack.prod.js"
+    "build": "webpack --config config/webpack.prod.js",
+    "babel": "yarn clean && babel src -d dist-babel",
+    "clean": "rm -rf dist; rm -rf dist-babel"
   }
 }


### PR DESCRIPTION
When using Babel with Webpack it is optimal to specify `modules: false` to Babel's `env` preset in order to **not** convert es6 import statements in `require`s. This is because Webpack both understands and relies on true import statements for tree-shaking.

This PR also adds a command to run JUST Babel on the web side, allowing for easier debugging and making sure it's doing what we expect. 