### PR TITLE
Remove postinstall db:up step.

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -16,6 +16,5 @@
     "db:save": "yarn prisma2 lift save",
     "db:seed": "node prisma/seeds",
     "build": "NODE_ENV=production yarn db:up && NODE_ENV=production babel src --out-dir dist",
-    "postinstall": "yarn db:up"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "db:seed": "yarn workspace api db:seed",
     "lint": "yarn eslint 'web/src/**/*.js' 'api/src/**/*.js'",
     "lint:fix": "yarn eslint --fix 'web/src/**/*.js' 'api/src/**/*.js'",
-    "postinstall": "yarn workspace api postinstall"
   },
   "version": "0.0.1-alpha.19"
 }


### PR DESCRIPTION
This removes the postinstall script which creates the database, applies migrations and generates the Prisma client after packages are installed.

We're removing this to allow `yarn create redwood-app` to work without interrupting the user. We will use `prisma --watch` during development.