### PR TITLE
Add redirects to netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,8 @@
   command = "yarn rw build"
   publish = "web/dist"
   functions = "api/dist/functions"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
Tested and deployed on redwoodblog, looks good: https://hungry-hawking-c81bc6.netlify.com/contact (used to 404)