### PR TITLE
Add possibility to configure host for development servers

### DIFF
--- a/redwood.toml
+++ b/redwood.toml
@@ -1,9 +1,13 @@
 [web]
   host = "localhost"
+  # if running inside docker container/VM
+  # host = "0.0.0.0"
   port = 8910
   apiProxyPath = "/.netlify/functions"
 [api]
   host = "localhost"
+  # if running inside docker container/VM
+  # host = "0.0.0.0"
   port = 8911
 [browser]
   open = true

--- a/redwood.toml
+++ b/redwood.toml
@@ -1,7 +1,9 @@
 [web]
+  host = "localhost"
   port = 8910
   apiProxyPath = "/.netlify/functions"
 [api]
+  host = "localhost"
   port = 8911
 [browser]
   open = true


### PR DESCRIPTION
This patch adds the possibility to run redwood within VM/containers, and still access the servers setting the config to "0.0.0.0".
An accompanying PR is at : https://github.com/redwoodjs/redwood/pull/216