### PR TITLE
Put binaryTargets in ENV var

### DIFF
--- a/.env
+++ b/.env
@@ -6,3 +6,4 @@
 # variables in Settings > Build & Deploy > environment
 #
 # DATABASE_URL=postgres://user:pass@postgreshost.com:5432/database_name
+# BINARY_TARGET=rhel-openssl-1.0.x

--- a/.env.defaults
+++ b/.env.defaults
@@ -4,3 +4,4 @@
 # into version control.
 
 DATABASE_URL=file:./dev.db
+BINARY_TARGET=native

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -5,7 +5,7 @@ datasource DS {
 
 generator photonjs {
   provider = "prisma-client-js"
-  binaryTargets = ["native", "rhel-openssl-1.0.x"]
+  binaryTargets = env("BINARY_TARGET")
 }
 
 // Define your own datamodels here and run `yarn redwood db save` to create


### PR DESCRIPTION
@peterp I noticed a couple of people saying they had to change binaryTargets to `["native", "windows"]` but I wonder if that's really necessary or if just `"native"` would work on its own. This PR assumes that just `"native"` is okay, can you test on your Window VM?

I'm going to update the tutorial once this goes into a real release to let users know they need to set the environment variable on Netlify to `"rhel-openssl-1.0.x"`.