### PR TITLE
Sort default packages order and format file

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -2,10 +2,12 @@
   "name": "web",
   "version": "0.0.0",
   "private": true,
-  "browserslist": ["defaults"],
+  "browserslist": [
+    "defaults"
+  ],
   "dependencies": {
-    "@redwoodjs/web": "^0.4.0",
     "@redwoodjs/router": "^0.4.0",
+    "@redwoodjs/web": "^0.4.0",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"


### PR DESCRIPTION
This ensures that a new application has its `web/package.json` file in order (in terms of formatting and packages sorting), so that running `yarn workspace web add` produces changes only to the newly added packages’ lines.