### PR TITLE
revert db.js foreignKeyReplacement workaround #50

### DIFF
--- a/api/src/lib/db.js
+++ b/api/src/lib/db.js
@@ -4,22 +4,3 @@
 import { PrismaClient } from '@prisma/client'
 
 export const db = new PrismaClient()
-
-// Using this as a workaround until Prisma has a chance to work on
-// https://github.com/prisma/prisma/issues/2152
-export const foreignKeyReplacement = (input) => {
-  let output = input
-  const foreignKeys = Object.keys(input).filter((k) => k.match(/Id$/))
-
-  foreignKeys.forEach((key) => {
-    const modelName = key.replace(/Id$/, '')
-    const value = input[key]
-
-    delete output[key]
-    output = Object.assign(output, {
-      [modelName]: { connect: { id: value } },
-    })
-  })
-
-  return output
-}


### PR DESCRIPTION
at this time, no longer implementing this workaround to support PrismaClient lack of userId support