### PR TITLE
Add explanatory comment to redwood.toml

### DIFF
--- a/redwood.toml
+++ b/redwood.toml
@@ -1,3 +1,9 @@
+# This file contains the configuration settings for your Redwood app.
+# This file is also what makes your Redwood app a Redwood app. If you remove it and try to run `yarn rw dev`, you'll get an error.
+#
+# For the full list of options, see config.ts: https://github.com/redwoodjs/redwood/blob/d51ade08118c17459cebcdb496197ea52485364a/packages/internal/src/config.ts#L42-L60.
+# By default, a Redwood app's apiProxyPath is the same as Netlify's.
+
 [web]
   port = 8910
   apiProxyPath = "/.netlify/functions"

--- a/redwood.toml
+++ b/redwood.toml
@@ -1,7 +1,8 @@
 # This file contains the configuration settings for your Redwood app.
 # This file is also what makes your Redwood app a Redwood app. If you remove it and try to run `yarn rw dev`, you'll get an error.
 #
-# For the full list of options, see config.ts: https://github.com/redwoodjs/redwood/blob/d51ade08118c17459cebcdb496197ea52485364a/packages/internal/src/config.ts#L42-L60.
+# For the full list of options, see the "App Configuration: redwood.toml" doc: 
+# https://redwoodjs.com/docs/app-configuration-redwood-toml
 # By default, a Redwood app's apiProxyPath is the same as Netlify's.
 
 [web]


### PR DESCRIPTION
This PR adds some explanatory comments to the top of `redwood.toml`, the same kind of content you see in [.env.defaults](https://github.com/redwoodjs/create-redwood-app/blob/532495a39c7d1ba9ea36001ba8d0f8f6264c4f3e/.env.defaults#L1-L4). Via https://github.com/redwoodjs/redwoodjs.com/pull/173.