### PR TITLE
Add env template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,9 @@
+# THIS FILE SHOULD NOT BE CHECKED INTO YOUR VERSION CONTROL SYSTEM
+#
+# Environment variables set here will override those in .env.defaults.
+# Any environment variables you need in production you will need to setup with
+# your hosting provider. For example in Netlify you can add environment
+# variables in Settings > Build & Deploy > environment
+#
+# DATABASE_URL=postgres://user:pass@postgreshost.com:5432/database_name
+# BINARY_TARGET=rhel-openssl-1.0.x

--- a/.env.template
+++ b/.env.template
@@ -1,9 +1,2 @@
-# THIS FILE SHOULD NOT BE CHECKED INTO YOUR VERSION CONTROL SYSTEM
-#
-# Environment variables set here will override those in .env.defaults.
-# Any environment variables you need in production you will need to setup with
-# your hosting provider. For example in Netlify you can add environment
-# variables in Settings > Build & Deploy > environment
-#
 # DATABASE_URL=postgres://user:pass@postgreshost.com:5432/database_name
 # BINARY_TARGET=rhel-openssl-1.0.x


### PR DESCRIPTION
I'd like to be able to clone a redwood app and have an environment template ready to copy and paste over to my local .env file. This template might grow with a list of required keys, .etc as I add features like Stripe integration to my app and it'd be nice for contributors to have an updated env template of right out of the box too. Presently, only the project initiator (the one who ran yarn create-react-app) will have a .env with Redwood's required configs as this doesn't get checked in (appropriately so).

Thanks for considering :)