### PR TITLE
Replace importAll with babel plugin

### DIFF
--- a/api/src/functions/graphql.js
+++ b/api/src/functions/graphql.js
@@ -3,12 +3,10 @@ import {
   makeMergedSchema,
   makeServices,
 } from '@redwoodjs/api'
-import importAll from '@redwoodjs/api/importAll.macro'
+import schemas from 'src/graphql/**/*.{js,ts}'
+import services from 'src/services/**/*.{js,ts}'
 
 import { db } from 'src/lib/db'
-
-const schemas = importAll('api', 'graphql')
-const services = importAll('api', 'services')
 
 export const handler = createGraphQLHandler({
   schema: makeMergedSchema({


### PR DESCRIPTION
Complementary PR to https://github.com/redwoodjs/redwood/pull/788, which removed the importAll.macro in favor of a babel plugin that lets us use more-regular import syntax. Relevant to the schema stitching happening in `graphql.js` (the serverless function).