### PR TITLE
Update constructor doc link

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,9 @@
+# THIS FILE SHOULD NOT BE CHECKED INTO YOUR VERSION CONTROL SYSTEM
+#
+# Environment variables set here will override those in .env.defaults.
+# Any environment variables you need in production you will need to setup with
+# your hosting provider. For example in Netlify you can add environment
+# variables in Settings > Build & Deploy > environment
+#
+# DATABASE_URL=postgres://user:pass@postgreshost.com:5432/database_name
+# BINARY_TARGET=rhel-openssl-1.0.x

--- a/.env.template
+++ b/.env.template
@@ -1,9 +1,2 @@
-# THIS FILE SHOULD NOT BE CHECKED INTO YOUR VERSION CONTROL SYSTEM
-#
-# Environment variables set here will override those in .env.defaults.
-# Any environment variables you need in production you will need to setup with
-# your hosting provider. For example in Netlify you can add environment
-# variables in Settings > Build & Deploy > environment
-#
 # DATABASE_URL=postgres://user:pass@postgreshost.com:5432/database_name
 # BINARY_TARGET=rhel-openssl-1.0.x

--- a/api/src/lib/db.js
+++ b/api/src/lib/db.js
@@ -1,4 +1,4 @@
-// See https://github.com/prisma/prisma2/blob/master/docs/prisma-client-js/api.md#constructor
+// See https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/constructor
 // for options.
 
 import { PrismaClient } from '@prisma/client'


### PR DESCRIPTION
The commented url to documentation in db.js was bad.

- Was `https://github.com/prisma/prisma2/blob/master/docs/prisma-client-js/api.md#constructor`
- replaced with `https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/constructor`