### PR TITLE
Add env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# DATABASE_URL=file:./dev.db
+# BINARY_TARGET=native


### PR DESCRIPTION
Adds an .env.example so that post-init clones/forks have a config example. 