### PR TITLE
Update constructor doc link

### DIFF
--- a/api/src/lib/db.js
+++ b/api/src/lib/db.js
@@ -1,4 +1,4 @@
-// See https://github.com/prisma/prisma2/blob/master/docs/prisma-client-js/api.md#constructor
+// See https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/constructor
 // for options.
 
 import { PrismaClient } from '@prisma/client'


### PR DESCRIPTION
The commented url to documentation in db.js was bad.

- Was `https://github.com/prisma/prisma2/blob/master/docs/prisma-client-js/api.md#constructor`
- replaced with `https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/constructor`