### PR TITLE
Add all-contributors file with populated data

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,142 @@
+{
+  "projectName": "create-redwood-app",
+  "projectOwner": "redwoodjs",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "contributorTemplate": "<a href=\"<%= contributor.profile %>\"><img src=\"<%= contributor.avatar_url %>\" width=\"<%= options.imageSize %>px;\" alt=\"\"/><br /><sub><b><%= contributor.name %></b></sub></a>",
+  "commit": false,
+  "commitConvention": "none",
+  "contributors": [
+    {
+      "login": "peterp",
+      "name": "Peter Pistorius",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/44849?v=4",
+      "profile": "http://peterp.org/",
+      "contributions": [
+        "tool"
+      ]
+    },
+    {
+      "login": "thedavidprice",
+      "name": "David Price",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/2951?v=4",
+      "profile": "http://thedavidprice.com/",
+      "contributions": [
+        "tool"
+      ]
+    },
+    {
+      "login": "mojombo",
+      "name": "Tom Preston-Werner",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/1?v=4",
+      "profile": "http://tom.preston-werner.com/",
+      "contributions": [
+        "tool"
+      ]
+    },
+    {
+      "login": "cannikin",
+      "name": "Rob Cameron",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/300?v=4",
+      "profile": "http://ridingtheclutch.com/",
+      "contributions": [
+        "tool"
+      ]
+    },
+    {
+      "login": "jtoar",
+      "name": "Dominic Saadi",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/32992335?v=4",
+      "profile": "https://github.com/jtoar",
+      "contributions": [
+        "tool"
+      ]
+    },
+    {
+      "login": "Terris",
+      "name": "Terris Kremer",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/458233?v=4",
+      "profile": "http://terrisjkremer.com/",
+      "contributions": [
+        "tool"
+      ]
+    },
+    {
+      "login": "ackinc",
+      "name": "Anirudh Nimmagadda",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/4007598?v=4",
+      "profile": "https://github.com/ackinc",
+      "contributions": [
+        "tool"
+      ]
+    },
+    {
+      "login": "gfpacheco",
+      "name": "Guilherme Pacheco",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/3705660?v=4",
+      "profile": "https://github.com/gfpacheco",
+      "contributions": [
+        "tool"
+      ]
+    },
+    {
+      "login": "leonardoelias",
+      "name": "Leonardo Elias",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/1995213?v=4",
+      "profile": "https://github.com/leonardoelias",
+      "contributions": [
+        "tool"
+      ]
+    },
+    {
+      "login": "michelegera",
+      "name": "Michele Gerarduzzi",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/3891?v=4",
+      "profile": "https://github.com/michelegera",
+      "contributions": [
+        "tool"
+      ]
+    },
+    {
+      "login": "nikolasburk",
+      "name": "Nikolas",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/4058327?v=4",
+      "profile": "https://twitter.com/nikolasburk",
+      "contributions": [
+        "tool"
+      ]
+    },
+    {
+      "login": "RobertBroersma",
+      "name": "Robert",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/4519828?v=4",
+      "profile": "https://github.com/RobertBroersma",
+      "contributions": [
+        "tool"
+      ]
+    },
+    {
+      "login": "satyarohith",
+      "name": "Satya Rohith",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/29819102?v=4",
+      "profile": "https://satyarohith.com/",
+      "contributions": [
+        "tool"
+      ]
+    },
+    {
+      "login": "guledali",
+      "name": "guledali",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/20647282?v=4",
+      "profile": "https://github.com/guledali",
+      "contributions": [
+        "tool"
+      ]
+    }
+  ],
+  "contributorsPerLine": 7
+}

--- a/README.md
+++ b/README.md
@@ -64,3 +64,8 @@ yarn redwood db up
 This will read the schema definition in `api/prisma/schema.prisma` and generate a sqlite database in `api/prisma/dev.db`
 
 If you've made changes to the schema run `yarn redwood db save` to generate a migration, and `yarn redwood db up` to apply the migration/ generate a new ORM client.
+
+## Contributors
+
+Redwood is amazing thanks to a wonderful [community of contributors](https://github.com/redwoodjs/redwood/blob/main/README.md#contributors).
+


### PR DESCRIPTION
This is the configuration required for https://github.com/redwoodjs/redwood/pull/875

Individual contributors will be displayed on the Framework repo README. Using a GitHub action, data will be pulled from this config file.

I've added a link to this repo README.me to the Framework README Contributors section.

**Do not merge until 875 is sorted.**