### PR TITLE
[Code Mod] Disable Prisma CLI update notifier

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -3,5 +3,9 @@
 # system. Any custom values should go in .env and .env should *not* be checked
 # into version control.
 
+# schema.prisma defaults
 DATABASE_URL=file:./dev.db
 BINARY_TARGET=native
+
+# disables Prisma CLI update notifier
+PRISMA_HIDE_UPDATE_MESSAGE=true


### PR DESCRIPTION
Related to work on Prisma Upgrade and pinning Prisma version. Currently, Prisma CLI will prompt user to update if a new version is available. We do not want this 'cause, you know, bad things:
https://github.com/redwoodjs/redwood/pull/841

Documentation from https://github.com/prisma/prisma/releases/tag/2.1.0