### PR TITLE
Remove `dataMigrate up` from netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "yarn rw db up --no-db-client --auto-approve && yarn rw dataMigrate up && yarn rw build"
+  command = "yarn rw db up --no-db-client --auto-approve && yarn rw build"
   publish = "web/dist"
   functions = "api/dist/functions"
 


### PR DESCRIPTION
`dataMigrate up` requires Prisma Client to be built, but we specifically do not build the client at build time. :(