### PR TITLE
Use `/api` as default `apiProxyPath`

### DIFF
--- a/redwood.toml
+++ b/redwood.toml
@@ -9,7 +9,7 @@
 
 [web]
   port = 8910
-  apiProxyPath = "/.netlify/functions"
+  apiProxyPath = "/api"
 [api]
   port = 8911
 [browser]


### PR DESCRIPTION
This PR changes the default functions path to be`/api`.

This is a platform agnostic route and also very discoverable for end users.