### PR TITLE
add dollar prefix to prisma disconnect method

### DIFF
--- a/api/prisma/seeds.js
+++ b/api/prisma/seeds.js
@@ -22,5 +22,5 @@ async function main() {
 main()
   .catch((e) => console.error(e))
   .finally(async () => {
-    await db.disconnect()
+    await db.$disconnect()
   })


### PR DESCRIPTION
Similar to issue [#982](https://github.com/redwoodjs/redwood/issues/982) this PR adds a $ dollar prefix to the prisma disconnect method which was depreciated in [Prisma 2.4](https://github.com/prisma/prisma/releases/tag/2.4.0)