### PR TITLE
Adds decoupled.studio to vscode recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,7 +7,8 @@
     "wix.vscode-import-cost",
     "pflannery.vscode-versionlens",
     "editorconfig.editorconfig",
-    "prisma.prisma"
+    "prisma.prisma",
+    "decoupled.studio"
   ],
   "unwantedRecommendations": []
 }


### PR DESCRIPTION
## Description

I'm working through redwoodjs/redwood#916 and discovered that I was missing the VSCode extension [DecoupledStudio](https://marketplace.visualstudio.com/items?itemName=decoupled.studio). This PR introduces this extension as a recommendation as it provides a useful utility for developers.

## Changes

- Adds `decoupled.studio` identifier to recommended extensions list