### PR TITLE
Typo, suppress trailing comma

### DIFF
--- a/web/jsconfig.json
+++ b/web/jsconfig.json
@@ -4,7 +4,7 @@
     "paths": {
       "src/*": ["./src/*"]
     },
-    "jsx": "preserve",
+    "jsx": "preserve"
   },
   "include": ["src/**/*", "../.redwood/index.d.ts"]
 }


### PR DESCRIPTION
JSON standard does not allow trailing comma (RFC-7159)
Not essential for sure, but it appears as an error in IntelliJ, and possibly in various other IDE.