### PR TITLE
(re)add rhel-openssl-1.0.x to schema.prisma

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -7,7 +7,7 @@ datasource DS {
 
 generator client {
   provider      = "prisma-client-js"
-  binaryTargets = "native"
+  binaryTargets = ["native", "rhel-openssl-1.0.x"]
 }
 
 // Define your own datamodels here and run `yarn redwood db save` to create


### PR DESCRIPTION
Prisma v2.9.0 fails on deploy unless we set `binaryTargets = ["native", "rhel-openssl-1.0.x"]` in schema.prisma.

No one from Prisma or Netlify can explain why. 

But they all assure me everything is fine.

¯\_(ツ)_/¯