### PR TITLE
Add TEST_DATABASE_URL to the default .env

### DIFF
--- a/.env
+++ b/.env
@@ -7,4 +7,3 @@
 #
 # DATABASE_URL=postgres://user:pass@postgreshost.com:5432/database_name
 # TEST_DATABASE_URL=postgres://user:pass@postgreshost.com:5432/test_database_name
-# BINARY_TARGET=rhel-openssl-1.0.x

--- a/.env
+++ b/.env
@@ -6,4 +6,5 @@
 # variables in Settings > Build & Deploy > environment
 #
 # DATABASE_URL=postgres://user:pass@postgreshost.com:5432/database_name
+# TEST_DATABASE_URL=postgres://user:pass@postgreshost.com:5432/test_database_name
 # BINARY_TARGET=rhel-openssl-1.0.x

--- a/.env.defaults
+++ b/.env.defaults
@@ -6,5 +6,8 @@
 # schema.prisma defaults
 DATABASE_URL=file:./dev.db
 
+# location of the test database for api service scenarios (defaults to ./.redwood/test.db if not set)
+# TEST_DATABASE_URL=file:./.redwood/test.db
+
 # disables Prisma CLI update notifier
 PRISMA_HIDE_UPDATE_MESSAGE=true


### PR DESCRIPTION
Currently it is a bit implicit that you can use the `TEST_DATABASE_URL`
env variable. I was able to figure this out by looking through the
source code, and since someone posted this on the issue tracker it means
more people find it a bit implicit.

Fixes: https://github.com/redwoodjs/redwood/issues/1620